### PR TITLE
fix: 깨진 GitHub stats 카드 제거

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,3 @@
 [![LinkedIn](https://img.shields.io/badge/LinkedIn-0A66C2?style=flat-square&logo=linkedin&logoColor=white)](https://www.linkedin.com/in/jongwon-choi-366b5b111/)
 [![Website](https://img.shields.io/badge/jongwony.com-000000?style=flat-square&logo=safari&logoColor=white)](https://www.jongwony.com)
 
----
-
-<a href="https://github.com/jongwony">
-  <img src="https://github-readme-stats.vercel.app/api?username=jongwony&show_icons=true&count_private=true" alt="jongwony" height="150" />
-</a>
-<a href="https://github.com/jongwony">
-  <img src="https://github-readme-stats.vercel.app/api/top-langs/?username=jongwony&layout=compact&hide=html,css,asp,php&langs_count=5" alt="top_langs" height="150" />
-</a>


### PR DESCRIPTION
## Summary
- github-readme-stats.vercel.app 이미지가 렌더링되지 않아 제거
- 깔끔한 프로필 카드 유지를 위한 후속 수정

## Test plan
- [ ] GitHub 프로필 페이지에서 깨진 이미지 없이 렌더링 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)