### PR TITLE
Fix missing space between role text and employer link

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -32,10 +32,7 @@ const links = [
   <body>
     <main>
       <h1>Jongwon Choi</h1>
-      <p class="role">
-        Data Engineer at
-        <a href="https://delightroom.com/">딜라이트룸 (Alarmy)</a>
-      </p>
+      <p class="role">Data Engineer at <a href="https://delightroom.com/">딜라이트룸 (Alarmy)</a></p>
       <p class="note">사이트를 새로 만드는 중입니다. 그동안은 아래에서 만나요.</p>
       <ul class="links">
         {


### PR DESCRIPTION
모바일에서 확인한 라이브 렌더링 버그입니다.

**증상**: `Data Engineer at딜라이트룸 (Alarmy)` — "at"과 회사명 사이 공백 없음

**원인**: Astro 컴파일러가 텍스트 노드와 뒤따르는 엘리먼트 사이의 줄바꿈·들여쓰기를 잘라냅니다. 소스의 줄바꿈이 공백으로 보존되지 않았습니다.

**확인**:
```
서빙 중 : 61 74 3c        (at<)
수정 후 : 61 74 20 3c     (at <)
```

텍스트와 앵커를 한 줄에 두고 리터럴 공백을 넣었습니다. 재빌드 산출물에서 확인했고, `dist/CNAME`도 그대로 이월됨을 함께 확인했습니다.

빌드는 어느 쪽이든 성공하므로 테스트로는 안 잡힙니다 — 배포된 페이지를 눈으로 봐서 발견했습니다.