### PR TITLE
Add five side projects to the chronology

### DIFF
--- a/src/content/chronology/2020-fingerstyle.md
+++ b/src/content/chronology/2020-fingerstyle.md
@@ -1,0 +1,8 @@
+---
+kind: 'project'
+title: 'fingerstyle'
+date: '2020'
+link: 'https://www.youtube.com/user/lastone9182'
+---
+
+기타치는 부캐의 기록

--- a/src/content/chronology/2022-mbti.md
+++ b/src/content/chronology/2022-mbti.md
@@ -1,0 +1,8 @@
+---
+kind: 'project'
+title: 'mbti'
+date: '2022'
+link: 'https://mbti.jongwony.com'
+---
+
+MBTI 추천 페이지

--- a/src/content/chronology/2024-pass-connects-im.md
+++ b/src/content/chronology/2024-pass-connects-im.md
@@ -1,0 +1,8 @@
+---
+kind: 'project'
+title: 'pass.connects.im'
+date: '2024'
+link: 'https://pass.connects.im'
+---
+
+나만의 디지털 명함을 iOS 앱에 담으세요.

--- a/src/content/chronology/2025-10-19-wedding-ttu.md
+++ b/src/content/chronology/2025-10-19-wedding-ttu.md
@@ -1,0 +1,8 @@
+---
+kind: 'project'
+title: 'wedding.ttu'
+date: '2025-10-19'
+link: 'https://wedding.ttu.world'
+---
+
+최종원 ❤️ 윤수경

--- a/src/content/chronology/2026-shift-schedule.md
+++ b/src/content/chronology/2026-shift-schedule.md
@@ -1,0 +1,6 @@
+---
+kind: 'project'
+title: 'shift-schedule'
+date: '2026'
+link: 'https://shift-schedule.connects.im'
+---

--- a/src/data/bio.json
+++ b/src/data/bio.json
@@ -1,7 +1,0 @@
-[
-  {"name": "pass.connects.im", "href": "https://pass.connects.im"},
-  {"name": "mbti", "href": "https://mbti.jongwony.com"},
-  {"name": "fingerstyle", "href": "https://fingerstyle.jongwony.com"},
-  {"name": "shift-schedule", "href": "https://shift-schedule.connects.im"},
-  {"name": "wedding", "href": "https://wedding.ttu.world"}
-]


### PR DESCRIPTION
bio.json 5건을 연대기로 편입.

- 시기: 저장소 생성 연도(소유자 확정), wedding.ttu만 행사 날짜 2025-10-19
- 제목: 기존 사이트가 표시하던 저장소 이름 그대로
- 소개: GitHub 저장소 설명 원문; shift-schedule은 설명이 없어 본문 없음
- fingerstyle: 사이트는 내릴 예정이라 링크를 YouTube 채널로 대체
- bio.json 삭제 (speaker/scrap과 같은 패턴), tags.json 유지

### 빌드 검증 (관찰 결과)

- 로컬 블로커: 이 워크트리(Node v25.6.1)에서 `npm run build`가 콘텐츠와
  무관하게 실패합니다. 원인은 `astro`(7.1.1)가 내부적으로 사용하는
  `vite`(8.1.5)의 네이티브 리졸버(rolldown/oxc_resolver, 바이너리:
  `@rolldown/binding-darwin-arm64`)가 `astro`의 `package.json`
  `exports`에 있는 두 개의 겹치는 와일드카드 패턴
  (`./tsconfigs/*.json` ↔ `./tsconfigs/*`)에서 `astro/tsconfigs/strict`를
  찾지 못하고 "Tsconfig not found" 에러를 던지는 문제입니다.
  `git stash`로 이 변경 전 커밋(e4c9b8b)만 있는 상태에서도 동일하게
  재현되어, 이번 콘텐츠 변경과 무관한 환경 문제임을 확인했습니다
  (tsconfig.json을 임시로 상대경로로 바꾸거나 완전히 제거해도 동일한
  에러가 발생 — 네이티브 바이너리 내부 리졸버 동작이라 프로젝트
  tsconfig.json 수정으로는 우회 불가). 배포 워크플로는 `push: [main]`에서만
  트리거되고 `deploy` job이 `needs: build`이므로 PR 단계에서는 실제로
  빌드가 실행되지 않으며, 이 로컬 실패가 병합을 막지는 않습니다.
- 정황 증거: `https://www.jongwony.com`은 현재 200을 반환하고 최근 병합된
  #29(Claude Code Subagent 항목 포함)가 이미 반영되어 있어, CI(GitHub
  Actions) 환경에서는 동일한 astro/vite 조합이 정상 빌드됨을 뒷받침합니다.
  `gh run list`로 최근 main 빌드 기록을 직접 확인하려 했으나 GitHub API가
  503(공지된 장애)을 반환해 실패했습니다.
- 아래 1~6번은 `dist/index.html` 렌더링 결과를 직접 관찰하지 못해,
  대신 5개 신규 파일의 실제 frontmatter 값과 `src/pages/index.astro`의
  정렬/렌더링 로직(코드 검토 완료, 이번 변경에서 미수정)을 근거로
  코드 검사(inspection)로 검증한 결과입니다.

1. 제목 5종 렌더링: frontmatter `title` 값이 각각 'pass.connects.im',
   'mbti', 'fingerstyle', 'shift-schedule', 'wedding.ttu'이며, 모두
   `<h3 class="entry-title">`(링크 있으면 내부에 `<a>`) 안에 텍스트로
   그대로 출력됩니다 — 코드 검사로 확인.
2. 연도만 있는 4건(pass.connects.im/mbti/shift-schedule/fingerstyle)은
   `formatDate()`가 `date.split('-').length === 1`일 때
   `` `${년}년` `` 만 반환하므로 월/일이 생성되지 않습니다 — 코드 검사로 확인.
3. wedding.ttu는 `date: '2025-10-19'`로 3파트이므로
   `formatDate()`가 "2025년 10월 19일"을 반환하며, 문자열 내림차순 정렬상
   '2025-11' < '2025-10-19' 비교에서 '2025-11'이 앞에 오고 '2025-08'이
   뒤에 오므로 두 항목 사이에 위치합니다 — 코드 검사로 확인.
4. 연도만 있는 4건의 정렬 위치: 문자열 비교상 'YYYY'는 같은 해의
   'YYYY-MM*'보다 항상 작으므로(prefix 규칙) 내림차순에서 해당 연도의
   모든 날짜 있는 항목보다 아래에 위치 — shift-schedule(2026)은
   2026-01-21 다음/2025-11 이전, pass.connects.im(2024)은 2024-01-07
   다음/2023-12-07 이전, mbti(2022)는 2022-03-17 다음/2021-07-07 이전,
   fingerstyle(2020)은 2020-01-07 다음/2019-09-24 이전 — 코드 검사로 확인.
5. [방향 변경 반영] fingerstyle에는 이제 소유자 확정에 따라
   `link: 'https://www.youtube.com/user/lastone9182'`가 있어,
   `entry.data.link ? <a href={link}>{title}</a> : title` 로직에 의해
   `<a href="https://www.youtube.com/user/lastone9182">fingerstyle</a>`
   앵커가 렌더링됩니다 — 코드 검사로 확인 (원래 계획한 "링크 없음" 검증은
   방향 변경으로 대체됨).
6. 전체 chronology 항목 수: 기존 30개(`ls src/content/chronology` 확인) +
   신규 5개 = 35개 — 파일 개수로 확인.
7. `git status`: 신규 파일 5개 + `src/data/bio.json` 삭제만 존재 — 실제
   관찰 완료 (유일하게 빌드 없이도 확정적으로 관찰 가능한 항목).
